### PR TITLE
add truncate environemt variable to Simple Access Control documentation

### DIFF
--- a/authorization/simple-access-control.md
+++ b/authorization/simple-access-control.md
@@ -16,6 +16,7 @@ ALLOW_TOPIC_PRODUCE=true      # Allow users to write new messages to topics
 ALLOW_TOPIC_CREATE=true       # Allow users to create new topics
 ALLOW_TOPIC_EDIT=true         # Allow users to edit topic configuration
 ALLOW_TOPIC_DELETE=true       # Allow users to delete topics
+ALLOW_TOPIC_TRUNCATE=true     # Allow users to delete messages
 ALLOW_GROUP_EDIT=true         # Allow users to delete consumer groups and reset consumer offsets
 ALLOW_BROKER_EDIT=true        # Allow users to edit broker configuration
 ALLOW_ACL_EDIT=true           # Allow users to create and delete Kafka ACLs

--- a/user-authorization/overview.md
+++ b/user-authorization/overview.md
@@ -24,6 +24,7 @@ The following actions are supported by both methods of access control.
 |  | **TOPIC\_CREATE** | Allow users to create new topics |
 |  | **TOPIC\_EDIT** | Allow users to edit topic configuration |
 |  | **TOPIC\_DELETE** | Allow users to delete topics |
+|  | **TOPIC\_TRUNCATE** | Allow users to delete messages in topics |
 |  | **GROUP\_EDIT** | Allow users to delete consumer groups and reset consumer offsets |
 |  | **BROKER\_EDIT** | Allow users to edit broker configuration |
 | **SCHEMA** | **SCHEMA\_CREATE** | Allow users to create new schemas and subjects |


### PR DESCRIPTION
I think this is missing from the documentation.

What I also could not find was which ACL's are required for this to work?